### PR TITLE
Breadcrumbs improvements and HasParent trait

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- HasParent Trait. Allow any model to have nested Parents. This will handle the validating and generating of full nested slug paths. The model must have a `parent()` method. To filter specific folders to be removed when working with sub-domains, populate a protected array attribute on the model named `$domainMappedFolders`.
+- HasBreadcrumbs Trait. Now includes appended `breadcrumbs` attribute through trait constructor. Also published a working breadcrumb blade view `maxfactor::components.breadcrumb`.
+
 ## [1.0.1] - 2018-02-21
 
 ### Added

--- a/changelog.md
+++ b/changelog.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.1.0] - 2018-03-16
 
 ### Added
 

--- a/src/Maxfactor.php
+++ b/src/Maxfactor.php
@@ -16,4 +16,27 @@ class Maxfactor
     {
         return Carbon::now()->format('Y');
     }
+
+    /**
+     * Generate a Breadcrumb navigation trail. Set time travel to false to disable
+     * forward navigation. Useful in Checkout for example.
+     *
+     * @param boolean $timetravel
+     * @return Array|Collection
+     */
+    public static function bake($seed = [], bool $timetravel = true)
+    {
+        $future = false;
+
+        $bread = collect($seed)->map(function ($crumb) use (&$future, $timetravel) {
+            $status = $future && !$timetravel ? 'disabled' : 'enabled';
+            $future = ($currentCrumb = (url()->current() === $crumb['url']) ? 'current' : '') || $future;
+
+            $crumb['status'] = $currentCrumb ? : $status;
+
+            return $crumb;
+        });
+
+        return $bread;
+    }
 }

--- a/src/MaxfactorServiceProvider.php
+++ b/src/MaxfactorServiceProvider.php
@@ -15,7 +15,7 @@ class MaxfactorServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        //
+        $this->bootViews();
     }
 
     /**
@@ -28,5 +28,19 @@ class MaxfactorServiceProvider extends ServiceProvider
         $this->app->bind('maxfactor', Maxfactor::class);
         $this->app->bind('mx-countries', Countries::class);
         $this->app->bind('mx-format', Format::class);
+    }
+
+    /**
+     * Load custom views
+     *
+     * @return void
+     */
+    private function bootViews()
+    {
+        $this->loadViewsFrom(__DIR__.'/Webpage/Views', 'maxfactor');
+
+        $this->publishes([
+            __DIR__.'/resources/views' => resource_path('views/vendor/maxfactor'),
+        ]);
     }
 }

--- a/src/Webpage/Traits/HasBreadcrumbs.php
+++ b/src/Webpage/Traits/HasBreadcrumbs.php
@@ -5,6 +5,23 @@ namespace Maxfactor\Support\Webpage\Traits;
 trait HasBreadcrumbs
 {
     /**
+     * The accessors to append to the model's array form.
+     *
+     * @var array
+     */
+    protected $appendsBreadcrumbFields = [
+        'breadcrumbs',
+    ];
+
+    /**
+     * Called by constructor to load appends fields.
+     */
+    public function initHasBreadcrumbs()
+    {
+        $this->appends = array_merge($this->appends, $this->appendsBreadcrumbFields);
+    }
+
+    /**
      * Provides the breadcrumb for the front-end to render
      *
      * @return void
@@ -17,5 +34,10 @@ trait HasBreadcrumbs
                 'url' => '/'
             ],
         ]);
+    }
+
+    public function getBreadcrumbsAttribute()
+    {
+        return $this->seed();
     }
 }

--- a/src/Webpage/Traits/HasParent.php
+++ b/src/Webpage/Traits/HasParent.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Maxfactor\Support\Webpage\Traits;
+
+use Illuminate\Database\Eloquent\Builder;
+
+/**
+ * Allow any model to have nested Parents. This will handle the validating and generating of
+ * full nested slug paths.
+ *
+ * The model must have a `parent()` method.
+ *
+ * To filter specific folders to be removed when working with sub-domains, populate a protected
+ * array attribute on the model named `$domainMappedFolders`.
+ */
+trait HasParent
+{
+    /**
+     * The accessors to append to the model's array form.
+     *
+     * @var array
+     */
+    protected $appendsParentFields = [
+        'full_path',
+    ];
+
+    /**
+     * Called by constructor to load appends fields.
+     */
+    public function initHasParent()
+    {
+        $this->appends = array_merge($this->appends, $this->appendsParentFields);
+    }
+
+    /**
+     * Get full path.
+     *
+     * @return string Full path
+     */
+    protected function getFullPath($item = null)
+    {
+        if (!$item) {
+            $item = $this;
+        }
+
+        if (!$parent = $item->parent) {
+            return str_start($item->slug, '/');
+        }
+
+        return str_start(sprintf('%s%s', $this->getFullPath($parent), str_start($item->slug, '/')), '/');
+    }
+
+    /**
+     * Get root slug.
+     *
+     * @return string Root slug
+     */
+    public function getRootSlug()
+    {
+        $pathSections = explode('/', $this->getFullPath());
+
+        return collect($pathSections)->filter()->first();
+    }
+
+    /**
+     * Add full path attribute.
+     *
+     * @return string Full path
+     */
+    public function getFullPathAttribute()
+    {
+        $pathSections = explode('/', $this->getFullPath());
+
+        $slugsToExclude = array_wrap($this->domainMappedFolders);
+
+        $finalSlug = collect($pathSections)
+            ->filter()
+            ->reject(function ($slug) use ($slugsToExclude) {
+                return in_array($slug, $slugsToExclude);
+            })
+            ->implode('/');
+
+        return str_start($finalSlug, '/');
+    }
+
+    /**
+     * Lazy-load parent items
+     *
+     * @param Builder $query
+     * @return Builder
+     */
+    public function scopeWithParent(Builder $query)
+    {
+        return $query->with('parent');
+    }
+
+    /**
+     * Filter the model to only show items which match the full path
+     *
+     * @param Builder $query
+     * @param string $path
+     * @return Builder
+     */
+    public function scopeWhereFullPath(Builder $query, string $path)
+    {
+        $itemSlugs = explode('/', $path);
+
+        return $query->where('slug', '=', end($itemSlugs))
+            ->get()
+            ->filter(function ($item) use ($path) {
+                return $item->full_path === str_start($path, '/');
+            });
+    }
+}

--- a/src/Webpage/Views/components/breadcrumb.blade.php
+++ b/src/Webpage/Views/components/breadcrumb.blade.php
@@ -1,0 +1,24 @@
+@if (isset($seed))
+<div class="breadcrumb">
+    <ul class="breadcrumb__group" itemscope itemtype="http://schema.org/BreadcrumbList">
+        @foreach (Maxfactor::bake($seed, isset($timetravel) ? $timetravel : true) as $crumb)
+            @if ($crumb['status'] === 'enabled')
+                <li class="breadcrumb__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
+                    <a href="{{ $crumb['url'] }}">{{ $crumb['name'] }}</a>
+                    <meta itemprop="position" content="{{ $loop->iteration }}" />
+                </li>
+            @elseif ($crumb['status'] === 'current')
+                <li class="breadcrumb__item breadcrumb__item--current" aria-current="true" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
+                    <a href="{{ $crumb['url'] }}">{{ $crumb['name'] }}</a>
+                    <meta itemprop="position" content="{{ $loop->iteration }}" />
+                </li>
+            @elseif ($crumb['status'] === 'disabled')
+                <li class="breadcrumb__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
+                    {{ $crumb['name'] }}
+                    <meta itemprop="position" content="{{ $loop->iteration }}" />
+                </li>
+            @endif
+        @endforeach 
+    </ul>
+</div>
+@endif


### PR DESCRIPTION
**HasParent Trait**. Allow any model to have nested Parents. This will handle the validating and generating of full nested slug paths. The model must have a `parent()` method. To filter specific folders to be removed when working with sub-domains, populate a protected array attribute on the model named `$domainMappedFolders`.

**HasBreadcrumbs Trait**. Now includes appended `breadcrumbs` attribute through trait constructor. Also published a working breadcrumb blade view `maxfactor::components.breadcrumb`.