### PR TITLE
Middleware and Trait to manage Canonical URLs

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - HasParent Trait. Allow any model to have nested Parents. This will handle the validating and generating of full nested slug paths. The model must have a `parent()` method. To filter specific folders to be removed when working with sub-domains, populate a protected array attribute on the model named `$domainMappedFolders`.
 - HasBreadcrumbs Trait. Now includes appended `breadcrumbs` attribute through trait constructor. Also published a working breadcrumb blade view `maxfactor::components.breadcrumb`.
+- MustHaveCanonical Trait and Middleware. Includes a Link rel canonical header to SEO duplication.
 
 ## [1.0.1] - 2018-02-21
 

--- a/src/Webpage/Contracts/Webpage.php
+++ b/src/Webpage/Contracts/Webpage.php
@@ -10,4 +10,11 @@ interface Webpage
      * @return Array
      */
     public function seed();
+
+    /**
+     * Ensure all Webpages have a canonical URL to avoid SEO problems
+     *
+     * @return string
+     */
+    public function getCanonicalAttribute();
 }

--- a/src/Webpage/Middleware/CanonicalHeader.php
+++ b/src/Webpage/Middleware/CanonicalHeader.php
@@ -21,6 +21,10 @@ class CanonicalHeader
             return $response;
         }
 
+        if (is_numeric($original)) {
+            return $response;
+        }
+
         $responseData = collect($original->getData())->toArray();
 
         $canonical = collect($responseData)->map(function ($item, $key) {

--- a/src/Webpage/Middleware/CanonicalHeader.php
+++ b/src/Webpage/Middleware/CanonicalHeader.php
@@ -21,7 +21,7 @@ class CanonicalHeader
             return $response;
         }
 
-        if (is_numeric($original)) {
+        if (!method_exists($original, 'getData')) {
             return $response;
         }
 

--- a/src/Webpage/Middleware/CanonicalHeader.php
+++ b/src/Webpage/Middleware/CanonicalHeader.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Maxfactor\Support\Webpage\Middleware;
+
+use Closure;
+
+class CanonicalHeader
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        $response = $next($request);
+        $responseData = collect($response->original->getData())->toArray();
+
+        $canonical = collect($responseData)->map(function ($item, $key) {
+            return collect($item)->get('canonical') ?? null;
+        })->first();
+
+        if ($canonical) {
+            $response->header(
+                'Link',
+                sprintf('<%s>; rel="canonical"', secure_url($canonical))
+            );
+        }
+
+        return $response;
+    }
+}

--- a/src/Webpage/Middleware/CanonicalHeader.php
+++ b/src/Webpage/Middleware/CanonicalHeader.php
@@ -16,7 +16,12 @@ class CanonicalHeader
     public function handle($request, Closure $next)
     {
         $response = $next($request);
-        $responseData = collect($response->original->getData())->toArray();
+
+        if (!$original = $response->original) {
+            return $response;
+        }
+
+        $responseData = collect($original->getData())->toArray();
 
         $canonical = collect($responseData)->map(function ($item, $key) {
             return collect($item)->get('canonical') ?? null;

--- a/src/Webpage/Traits/MustHaveCanonical.php
+++ b/src/Webpage/Traits/MustHaveCanonical.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Maxfactor\Support\Webpage\Traits;
+
+trait MustHaveCanonical
+{
+    /**
+     * The accessors to append to the model's array form.
+     *
+     * @var array
+     */
+    protected $appendsCanonicalFields = [
+        'canonical',
+    ];
+
+    /**
+     * Called by constructor to load appends fields.
+     */
+    public function initMustHaveCanonical()
+    {
+        $this->appends = array_merge($this->appends, $this->appendsCanonicalFields);
+    }
+}


### PR DESCRIPTION
To make this work include the Middleware in the `web` routes inside `kernel.php`, implement the Webpage middleware (this is useful for ensuring that all the required methods are actually implemented (avoid hard-to debug issues), and then include the `getCanonicalAttribute` in the model. This can return a relative URL, the middleware will convert it into a secure_url complete with domain name automatically if required.