### PR TITLE
Remove index page

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changes
+
+- Removed the index url (/) from being included by default when generating the sitemap
+
 ## [1.4.0] - 2018-09-12
 
 ### Added

--- a/src/Webpage/Commands/MakeSitemap.php
+++ b/src/Webpage/Commands/MakeSitemap.php
@@ -36,7 +36,6 @@ class MakeSitemap extends Command
         parent::__construct();
 
         $this->sitemap = $sitemap;
-        $this->sitemap->add(\URL::to('/'));
     }
 
     /**


### PR DESCRIPTION
The package shouldn't assume that we want to include a route to the index url so have removed this from the default behaviour.