### PR TITLE
Root parent helper

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [2.2.0] – 2019-01-15
+
+### Added
+
+- rootParent attribute to return the top root page object. Can use useful when wanting to always list sub-navigation items from the root for aside etc.
+
 ## [2.1.0] – 2019-01-03
 
 ### Added

--- a/src/Webpage/Traits/HasParent.php
+++ b/src/Webpage/Traits/HasParent.php
@@ -69,6 +69,20 @@ trait HasParent
     }
 
     /**
+     * Get root parent.
+     *
+     * @return self
+     */
+    public function getRootParentAttribute()
+    {
+        if (!$this->parent) {
+            return null;
+        }
+
+        return self::whereSlug($this->getRootSlug())->first();
+    }
+
+    /**
      * Add full path attribute.
      *
      * @return string Full path


### PR DESCRIPTION
Return the root parent object. Useful when listing sub-navigation items and wanting to always start at the root