### PR TITLE
Breadcrumb active state

### DIFF
--- a/src/Maxfactor.php
+++ b/src/Maxfactor.php
@@ -34,7 +34,7 @@ class Maxfactor
             }
 
             $status = $future && !$timetravel ? 'disabled' : 'enabled';
-            $future = ($currentCrumb = (url()->current() === array_get($crumb, 'url')) ? 'current' : '') || $future;
+            $future = ($currentCrumb = (url()->all() === array_get($crumb, 'url')) ? 'current' : '') || $future;
 
             $crumb['status'] = $currentCrumb ? : $status;
 

--- a/src/Maxfactor.php
+++ b/src/Maxfactor.php
@@ -34,7 +34,7 @@ class Maxfactor
             }
 
             $status = $future && !$timetravel ? 'disabled' : 'enabled';
-            $future = ($currentCrumb = (url()->all() === array_get($crumb, 'url')) ? 'current' : '') || $future;
+            $future = ($currentCrumb = (url()->full() === array_get($crumb, 'url')) ? 'current' : '') || $future;
 
             $crumb['status'] = $currentCrumb ? : $status;
 


### PR DESCRIPTION
The breadcrumb active state was not working on paths which include query string parameters.

I've changed the current url in the comparison to the `->full()` url which includes the query parameters.

It works backwards with urls without query parameters so I don't see any harm in doing this.