### PR TITLE
Helper method to filter querystrings. E.g. for use in canonicals.

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,16 @@ Inside the head of your blade layout (or view) render the canonical meta field.
 @include('maxfactor::components.canonical')
 ```
 
+The Maxfactor facade also includes an additional helper method which can be used to deal with Querystring parameters in the canonical url. The `urlWithQuerystring` method accepts the desired url and a string or regular expression to filter which parameters to include in the output. The query values are taken from the current request query, even though the destination url doesn't have to match this. Here's an example of how this could be used to include pagination.
+
+```php
+// Assuming the current url is https://example.com/journal?page=2&tag=news
+
+Maxfactor::urlWithQuerystring('https://example.com/blog', $allowedParameters = 'page=[^1]');
+
+// returns https://example.com/blog?page=2
+```
+
 ### Sitemap
 
 To generate a sitemap simply create a new Command and Extend the `MakeSitemap` command in this package. Then add it to your console kernel and schedule as required. Here is the template to use as starting point.

--- a/src/Maxfactor.php
+++ b/src/Maxfactor.php
@@ -43,4 +43,32 @@ class Maxfactor
 
         return $bread;
     }
+
+    /**
+     * Returns a url with query string where the final querystring is a filtered
+     * version of the current querystring.
+     *
+     * @param string $url
+     * @param string $allowedParameters  Accepts a string or regular expression
+     * @return string
+     */
+    public function urlWithQuerystring(string $url, string $allowedParameters = null) : string
+    {
+        if (!$allowedParameters) {
+            return $url;
+        }
+
+        $allowedParameters = str_start($allowedParameters, '/');
+        $allowedParameters = str_finish($allowedParameters, '/');
+
+        $currentQuery = collect(request()->query())->filter(function ($value, $parameter) use ($allowedParameters) {
+            return preg_match($allowedParameters, sprintf('%s=%s', $parameter, $value));
+        });
+
+        if (!$newQuery = http_build_query($currentQuery->all())) {
+            return $url;
+        };
+
+        return sprintf('%s?%s', $url, $newQuery);
+    }
 }


### PR DESCRIPTION
To resolve #23 , this PR adds a helper method to filter querystring using a regular expression. This will need to be implemented specifically for any areas which should index pagination (e.g. we can use this in the blog package by default).

The `urlWithQuerystring` method accepts the desired url and a string or regular expression to filter which parameters to include in the output. The query values are taken from the current request query, even though the destination url doesn't have to match this. Here's an example of how this could be used to include pagination.

```php
// Assuming the current url is https://example.com/journal?page=2&tag=news

Maxfactor::urlWithQuerystring('https://example.com/blog', $allowedParameters = 'page=[^1]');

// returns https://example.com/blog?page=2
```