### PR TITLE
Allow additional meta fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,23 @@ And this is a pre-made component to render the meta description
 @render('maxfactor:webpage::metaDescription', ['description' => array_get($page ?? [], 'metaDescription')])
 ```
 
+#### Additional Meta Fields in Nova
+
+You can pass in additional meta fields into the `MetaAttributes::make()` function, to display your own fields in the 'Meta Attributes' panel that this package creates.
+
+```php
+// Define our additional fields in the resource.
+protected function additionalMetaFields()
+{
+    return [
+        Text::make('Example Meta Content'),
+    ];
+}
+
+// Inside the resources fields() function we can pass in our additional fields as a parameter.
+MetaAttributes::make($this->additionalMetaFields()),
+```
+
 ### Slugs
 
 Add the `Maxfactor\Support\Webpage\Traits\HasSlug` trait to your model if you want the route helper to use the `slug` column in your database to identify records. (E.g. `/blog/article/foo` instead of `/blog/article/1`).

--- a/src/Webpage/Nova/MetaAttributes.php
+++ b/src/Webpage/Nova/MetaAttributes.php
@@ -10,9 +10,9 @@ use ElevateDigital\CharcountedFields\TextareaCounted;
 
 class MetaAttributes
 {
-    public static function make()
+    public static function make($additionalFields = [])
     {
-        return new Panel(__('Meta Attributes'), self::fields());
+        return new Panel(__('Meta Attributes'), array_merge(self::fields(), $additionalFields));
     }
 
     protected static function fields()


### PR DESCRIPTION
This came to mind whilst working on the meta attributes for non-page related output, so I thought it would be worth airing the idea 😃 

Allows for additional fields to be passed into the `make()` function like so: 

```php
// Inside the resources fields() function...
MetaAttributes::make($this->additionalMetaFields()),

// Elsewhere in the resource.
protected function additionalMetaFields()
{
    return [
        Textarea::make('Gallery Meta Description', 'gallery_meta')
            ->hideFromIndex(),
    ];
}
```

The only point in this really is to display additional meta fields in the separate 'Meta Attributes'  panel generated by this package, making for a cleaner and easier to digest details view in Nova!