### PR TITLE
Remove char counted fields. Causing nova error in non-nova repos

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,6 @@
         "dereuromark/media-embed": "^0.4.1",
         "spatie/laravel-view-components": "^1.1",
         "laravelium/sitemap": "^2.0|^3.0",
-        "elevate-digital/nova-charcounted-fields": "dev-master",
         "dannyvankooten/laravel-vat": "^2.0"
     },
     "autoload": {

--- a/src/Webpage/Nova/MetaAttributes.php
+++ b/src/Webpage/Nova/MetaAttributes.php
@@ -5,8 +5,6 @@ namespace Maxfactor\Support\Webpage\Nova;
 use Laravel\Nova\Panel;
 use Laravel\Nova\Fields\Text;
 use Laravel\Nova\Fields\Textarea;
-use ElevateDigital\CharcountedFields\TextCounted;
-use ElevateDigital\CharcountedFields\TextareaCounted;
 
 class MetaAttributes
 {
@@ -19,14 +17,9 @@ class MetaAttributes
     {
         return [
             Text::make('H1')->hideFromIndex(),
-            TextCounted::make('Browser Title')
-                ->hideFromIndex()
-                ->maxChars(60)
-                ->warningAt(50),
+            Text::make('Browser Title')->hideFromIndex(),
             Text::make('Nav Title')->hideFromIndex(),
-            TextareaCounted::make('Meta Description')
-                ->maxChars(300)
-                ->warningAt(250),
+            Textarea::make('Meta Description')
         ];
     }
 }


### PR DESCRIPTION
this was causing issues when updating this package in a non-nova repo. The `elevate-digital/nova-charcounted-fields` package has been abandoned too, so makes sense to drop it.